### PR TITLE
fix: Correct installation directory in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Before you begin, ensure you have the following installed:
 
 1.  **Clone the repository**:
     ```sh
-    git clone https://github.com/solarfresh/ag2-playground.git
-    cd twinrad
+    git clone https://github.com/ai-twinkle/TwinRAD.git
+    cd TwinRAD
     ```
 2.  **Create a virtual environment** (recommended):
     ```sh


### PR DESCRIPTION
- Fix the correct repo URL to clone
- Fix directory name: `cd twinrad` → `cd TwinRAD`

This resolves the incorrect directory name in the installation instructions.