### PR TITLE
feat(clients): Add base handler and client schemas

### DIFF
--- a/src/twinrad/clients/handlers/base_handler.py
+++ b/src/twinrad/clients/handlers/base_handler.py
@@ -1,0 +1,21 @@
+from abc import ABC, abstractmethod
+
+from twinrad.schemas.clients import LLMRequest, LLMResponse
+
+
+class BaseHandler(ABC):
+    """
+    An abstract base class that defines the common interface for all
+    language model handlers.
+    """
+
+    @abstractmethod
+    def generate(self, request: LLMRequest) -> LLMResponse:
+        """
+        Abstract method to generate a response from a language model.
+
+        All concrete handler implementations (e.g., VllmHandler, HttpHandler)
+        must implement this method to process a standardized LLMRequest
+        and return a standardized LLMResponse.
+        """
+        pass

--- a/src/twinrad/schemas/clients.py
+++ b/src/twinrad/schemas/clients.py
@@ -1,0 +1,26 @@
+from typing import Literal, Optional
+
+from pydantic import BaseModel, NonNegativeInt
+
+
+class LLMRequest(BaseModel):
+    """A standardized schema for all model inference requests."""
+    model_name: str
+    prompt: str
+    max_tokens: NonNegativeInt = 256
+    temperature: float = 0.7
+    top_p: float = 0.95
+
+
+class LLMResponse(BaseModel):
+    """A standardized schema for all model inference responses."""
+    text: str
+
+
+class ModelConfig(BaseModel):
+    """Defines the configuration for a single model or API."""
+    name: str
+    mode: Literal["vllm", "openai", "generic_api"] = "generic_api"
+    path: Optional[str] = None
+    url: Optional[str] = None
+    api_key: Optional[str] = None


### PR DESCRIPTION
This commit introduces a new, standardized architecture for handling language model clients.

* **Base Handler**: Adds `BaseHandler`, an abstract class that defines a common interface for all language model handlers, ensuring they process a standardized `LLMRequest` and return a standardized `LLMResponse`.
* **Client Schemas**: Introduces new Pydantic models (`LLMRequest`, `LLMResponse`, and `ModelConfig`) to standardize data for all model inference requests and responses.