### PR TITLE
feat(clients): Add Gemini handler and unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,25 +29,14 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "ag2>=0.9.8",
-    "altair>=5.0.0",
-    "pydantic>=2.0.0",
-    "pydantic-settings>=2.0.0",
-    "python-dotenv>=1.0.0",
-    "python-socketio>=5.0.0",
-    "python-engineio>=4.0.0",
-    "streamlit>=1.30.0",
-    "numpy>=1.20.0,<3.0.0",
-    "pandas>=1.3.0",
-    "openai>=1.0.0",
-    "google-genai>=1.0.0",
-    "google-cloud-aiplatform>=1.0.0",
-    "eventlet>=0.30.0",
-    "requests>=2.25.0",
+    "pydantic>=2.11.7",
+    "pydantic-settings>=2.10.1",
+    "google-genai>=1.30.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=6.0",
+    "pytest>=8.4.1",
     "black",
     "flake8",
     "mypy",

--- a/src/twinrad/clients/handlers/gemini_handler.py
+++ b/src/twinrad/clients/handlers/gemini_handler.py
@@ -1,0 +1,51 @@
+from google import genai
+from google.genai import types
+
+from twinrad.clients.handlers.base_handler import BaseHandler
+from twinrad.schemas.clients import LLMRequest, LLMResponse, ModelConfig
+
+
+class GeminiHandler(BaseHandler):
+    def __init__(self, config: ModelConfig, api_key: str):
+        self.config = config
+        self.api_key = api_key
+        # Configure the Gemini API client
+        self.client = genai.Client(api_key=self.api_key)
+
+    def generate(self, request: LLMRequest) -> LLMResponse:
+        """
+        Generates a response from the Gemini API based on a standardized request.
+        """
+        try:
+            # Prepare the request payload for Gemini
+            # Note: Gemini's API often expects a list of messages, even for a single-turn request.
+            messages_payload = []
+            for msg in request.messages:
+                messages_payload.append(types.Part.from_text(text=msg.content))
+
+            # Extract generation configuration from the standardized request schema
+            generation_config = types.GenerateContentConfig(
+                system_instruction=request.system_message,
+                max_output_tokens=request.max_tokens,
+                temperature=request.temperature,
+                top_p=request.top_p
+            )
+
+            # Call the Gemini API
+            response = self.client.models.generate_content(
+                model=request.model,
+                contents=[types.UserContent(parts=messages_payload)],
+                config=generation_config
+            )
+
+            # Check for potential errors or blocked content
+            if not response or not response.text:
+                raise ValueError("Received an empty or invalid response from the Gemini API.")
+
+            # Extract the text and wrap it in the standardized response schema
+            response_text = response.text
+            return LLMResponse(text=response_text)
+
+        except Exception as e:
+            # Handle API-specific exceptions and provide a clear error message
+            raise RuntimeError(f"An error occurred while calling the Gemini API: {e}")

--- a/src/twinrad/schemas/clients.py
+++ b/src/twinrad/schemas/clients.py
@@ -1,13 +1,16 @@
-from typing import Literal, Optional
+from typing import List, Literal, Optional
 
 from pydantic import BaseModel, NonNegativeInt
+
+from twinrad.schemas.messages import Message
 
 
 class LLMRequest(BaseModel):
     """A standardized schema for all model inference requests."""
-    model_name: str
-    prompt: str
     max_tokens: NonNegativeInt = 256
+    messages: List[Message]
+    model: str
+    system_message: str = 'You are a helpful AI Assistant.'
     temperature: float = 0.7
     top_p: float = 0.95
 

--- a/tests/unit/clients/handlers/test_gemini_handler.py
+++ b/tests/unit/clients/handlers/test_gemini_handler.py
@@ -1,0 +1,88 @@
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+from google.genai import Client, types
+from google.genai.types import Candidate, GenerateContentResponse
+
+from twinrad.clients.handlers.gemini_handler import GeminiHandler
+from twinrad.schemas.clients import (LLMRequest, LLMResponse, Message,
+                                     ModelConfig)
+
+
+@pytest.fixture
+def mock_gemini_client():
+    """
+    Mocks the Gemini API client to prevent real API calls.
+    """
+    mock_client = MagicMock(spec=Client)
+
+    # Create a mock response object that mimics the real Gemini response structure.
+    mock_response = MagicMock(spec=GenerateContentResponse)
+    mock_response.candidates = [Candidate(content=types.UserContent(parts=[types.Part.from_text(text="Mocked Gemini response.")]))]
+    mock_response.text = "Mocked Gemini response."
+
+    mock_client.models.generate_content.return_value = mock_response
+    return mock_client
+
+
+@pytest.fixture
+def gemini_handler(mock_gemini_client):
+    """
+    Fixture to create a GeminiHandler instance with a mocked client.
+    """
+    config = ModelConfig(name="gemini-pro")
+    handler = GeminiHandler(config=config, api_key="dummy_api_key")
+    handler.client = mock_gemini_client
+    return handler
+
+
+def test_gemini_handler_generate_success(gemini_handler):
+    """
+    Test that the handler correctly processes a successful API response.
+    """
+    request = LLMRequest(
+        model="gemini-pro",
+        messages=[Message(role="user", content="Hello, Gemini.", name='Test')],
+        system_message="You are a helpful assistant.",
+        max_tokens=100,
+        temperature=0.7,
+        top_p=0.9
+    )
+
+    response = gemini_handler.generate(request)
+
+    # Assert that the handler returned the correct response schema
+    assert isinstance(response, LLMResponse)
+    assert response.text == "Mocked Gemini response."
+
+
+def test_gemini_handler_with_no_response(gemini_handler):
+    """
+    Test that the handler raises an error for an empty API response.
+    """
+    # Mock a response with no content
+    gemini_handler.client.models.generate_content.return_value = MagicMock(spec=GenerateContentResponse)
+
+    request = LLMRequest(
+        model="gemini-pro",
+        messages=[Message(role="user", content="Test empty response.", name='Test')],
+    )
+
+    with pytest.raises(RuntimeError, match="An error occurred while calling the Gemini API:.*"):
+        gemini_handler.generate(request)
+
+
+def test_gemini_handler_with_api_error(gemini_handler):
+    """
+    Test that the handler raises an error when the API call fails.
+    """
+    # Mock the API call to raise an exception
+    gemini_handler.client.models.generate_content.side_effect = Exception("API connection failed.")
+
+    request = LLMRequest(
+        model="gemini-pro",
+        messages=[Message(role="user", content="Test API error.", name='Test')],
+    )
+
+    with pytest.raises(RuntimeError, match="An error occurred while calling the Gemini API"):
+        gemini_handler.generate(request)


### PR DESCRIPTION
This pull request introduces the first concrete implementation of a client handler, with a focus on integrating the Gemini API and improving the client-side data schemas. It also includes comprehensive unit tests to ensure the new features are stable and reliable.

---

### Key Changes

* **New LLM Handler**: A dedicated `GeminiHandler` has been added to integrate with the `google-genai` library, providing a standardized way to communicate with the Gemini API.
* **Schema Refactoring**: The core `LLMRequest` schema was updated to support multi-turn conversations by replacing the single `prompt` field with a list of `messages`. This improves flexibility and aligns with modern LLM API standards.
* **Comprehensive Unit Tests**: A new test suite was created to validate the functionality of the `GeminiHandler`, covering successful responses, empty responses, and API errors.

---

### Detailed Breakdown

* **`GeminiHandler` Implementation**: This new handler adheres to the `BaseHandler` interface, ensuring a consistent contract for all future LLM client integrations. This allows for easier addition of new providers without disrupting the core client logic.
* **Updated `LLMRequest`**: The change from a single string `prompt` to a list of `messages` is a significant architectural improvement. It enables the system to handle conversational history more effectively, paving the way for more complex, stateful agent interactions.
* **Robust Testing**: The addition of mocked API calls in the unit tests provides a safety net, ensuring the handler works as expected without relying on external services. This is a crucial step for maintaining code quality and preventing regressions.

---

### Breaking Changes or Migration Notes

* **The `LLMRequest` schema has been modified.** The `prompt` field is now deprecated and has been replaced with a `messages` list and a `system_message` field. Any existing code that uses the old `LLMRequest` format will need to be updated.
