### PR TITLE
feat(clients): Add OpenAI handler and refactor schemas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "ag2>=0.9.8",
+    "openai==1.99.9",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.10.1",
     "google-genai>=1.30.0",

--- a/src/twinrad/clients/handlers/gemini_handler.py
+++ b/src/twinrad/clients/handlers/gemini_handler.py
@@ -6,11 +6,10 @@ from twinrad.schemas.clients import LLMRequest, LLMResponse, ModelConfig
 
 
 class GeminiHandler(BaseHandler):
-    def __init__(self, config: ModelConfig, api_key: str):
+    def __init__(self, config: ModelConfig):
         self.config = config
-        self.api_key = api_key
         # Configure the Gemini API client
-        self.client = genai.Client(api_key=self.api_key)
+        self.client = genai.Client(api_key=self.config.api_key)
 
     def generate(self, request: LLMRequest) -> LLMResponse:
         """

--- a/src/twinrad/clients/handlers/openai_handler.py
+++ b/src/twinrad/clients/handlers/openai_handler.py
@@ -1,0 +1,66 @@
+from typing import Optional
+
+import openai
+from openai import OpenAI
+from openai.types.chat.chat_completion import ChatCompletion
+
+from twinrad.clients.handlers.base_handler import BaseHandler
+from twinrad.schemas.clients import LLMRequest, LLMResponse, ModelConfig
+
+
+class OpenAIHandler(BaseHandler):
+    """
+    A concrete handler that adapts the OpenAI API to the BaseHandler interface.
+    """
+
+    def __init__(self, config: ModelConfig):
+        self.config = config
+        # The OpenAI client automatically reads from the OPENAI_API_KEY env var
+        # but we can explicitly pass it from the config.
+        self.client = OpenAI(api_key=self.config.api_key, base_url=self.config.base_url)
+
+    def generate(self, request: LLMRequest) -> LLMResponse:
+        """
+        Generates a response from the OpenAI API based on a standardized LLMRequest.
+
+        Args:
+            request (LLMRequest): The standardized request object.
+
+        Returns:
+            LLMResponse: The standardized response object.
+        """
+        try:
+            # 1. Adapt the standardized LLMRequest to OpenAI's format.
+            messages_payload = []
+            if request.system_message:
+                messages_payload.append({"role": "system", "content": request.system_message})
+
+            # The message payload should be a list of dictionaries with 'role' and 'content'
+            for msg in request.messages:
+                messages_payload.append({"role": msg.role, "content": msg.content})
+
+            # 2. Make the API call to OpenAI's Chat Completions endpoint.
+            response: ChatCompletion = self.client.chat.completions.create(
+                model=request.model,
+                messages=messages_payload,
+                max_tokens=request.max_tokens,
+                temperature=request.temperature,
+                top_p=request.top_p,
+            )
+
+            # 3. Handle potential API errors and adapt the response.
+            if not response.choices:
+                raise ValueError("Received an empty response from the OpenAI API.")
+
+            response_text: Optional[str] = response.choices[0].message.content
+            if response_text is None:
+                raise ValueError("Response text was None.")
+
+            return LLMResponse(text=response_text)
+
+        except openai.APIError as e:
+            # Re-raise with a generic runtime error for consistent error handling.
+            raise RuntimeError(f"An OpenAI API error occurred: {e}")
+        except Exception as e:
+            # Catch other potential errors
+            raise RuntimeError(f"An unexpected error occurred in OpenAIHandler: {e}")

--- a/src/twinrad/schemas/clients.py
+++ b/src/twinrad/schemas/clients.py
@@ -25,5 +25,5 @@ class ModelConfig(BaseModel):
     name: str
     mode: Literal["vllm", "openai", "generic_api"] = "generic_api"
     path: Optional[str] = None
-    url: Optional[str] = None
+    base_url: Optional[str] = None
     api_key: Optional[str] = None

--- a/tests/unit/clients/handlers/test_gemini_handler.py
+++ b/tests/unit/clients/handlers/test_gemini_handler.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import MagicMock
 
 import pytest
 from google.genai import Client, types
@@ -30,8 +30,8 @@ def gemini_handler(mock_gemini_client):
     """
     Fixture to create a GeminiHandler instance with a mocked client.
     """
-    config = ModelConfig(name="gemini-pro")
-    handler = GeminiHandler(config=config, api_key="dummy_api_key")
+    config = ModelConfig(name="gemini-pro", api_key="dummy_api_key")
+    handler = GeminiHandler(config=config)
     handler.client = mock_gemini_client
     return handler
 

--- a/tests/unit/clients/handlers/test_openai_handler.py
+++ b/tests/unit/clients/handlers/test_openai_handler.py
@@ -1,0 +1,110 @@
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from openai import APIError, OpenAI
+from openai.types.chat.chat_completion import ChatCompletion, Choice
+from openai.types.chat.chat_completion_message import ChatCompletionMessage
+from openai.types.completion_usage import CompletionUsage
+
+from twinrad.clients.handlers.openai_handler import OpenAIHandler
+from twinrad.schemas.clients import (LLMRequest, LLMResponse, Message,
+                                     ModelConfig)
+
+
+@pytest.fixture
+def mock_openai_client():
+    """
+    Mocks the OpenAI API client and its chat.completions.create method
+    to prevent real API calls.
+    """
+    mock_client = MagicMock(spec=OpenAI)
+    # Mock the return value of chat.completions.create()
+    mock_client.chat.completions.create.return_value = ChatCompletion(
+        id="chatcmpl-123",
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(
+                    content="Mocked OpenAI response.",
+                    role="assistant",
+                ),
+                logprobs=None,
+            )
+        ],
+        created=1677652288,
+        model="gpt-3.5-turbo",
+        object="chat.completion",
+        system_fingerprint="fp_44709d6fcb",
+        usage=CompletionUsage(completion_tokens=10, prompt_tokens=10, total_tokens=20)
+    )
+    return mock_client
+
+@pytest.fixture
+def openai_handler(mock_openai_client):
+    """
+    Fixture to create an OpenAIHandler instance with a mocked client.
+    """
+    config = ModelConfig(name="gpt-3.5-turbo", api_key="dummy_api_key")
+    handler = OpenAIHandler(config=config)
+    handler.client = mock_openai_client
+    return handler
+
+def test_openai_handler_generate_success(openai_handler):
+    """
+    Test that the handler correctly processes a successful API response.
+    """
+    # Create a standardized request to send to the handler
+    request = LLMRequest(
+        model="gpt-3.5-turbo",
+        messages=[Message(role="user", content="Hello, world.", name='Test')],
+        max_tokens=100,
+        temperature=0.7,
+        top_p=0.9
+    )
+
+    # Call the handler's generate method
+    response = openai_handler.generate(request)
+
+    # Assert that the handler returned the correct response schema and content
+    assert isinstance(response, LLMResponse)
+    assert response.text == "Mocked OpenAI response."
+
+def test_openai_handler_empty_response(openai_handler, mock_openai_client):
+    """
+    Test that the handler raises a ValueError for an empty API response.
+    """
+    # Mock the API call to return a response with no choices
+    mock_openai_client.chat.completions.create.return_value = ChatCompletion(
+        id="chatcmpl-empty",
+        choices=[],
+        created=1677652288,
+        model="gpt-3.5-turbo",
+        object="chat.completion",
+        system_fingerprint="fp_44709d6fcb",
+        usage=CompletionUsage(completion_tokens=0, prompt_tokens=10, total_tokens=10)
+    )
+
+    request = LLMRequest(
+        model="gpt-3.5-turbo",
+        messages=[Message(role="user", content="Test empty response.", name='Test')],
+    )
+
+    with pytest.raises(RuntimeError, match="An unexpected error occurred in OpenAIHandler:.*"):
+        openai_handler.generate(request)
+
+def test_openai_handler_api_error(openai_handler, mock_openai_client):
+    """
+    Test that the handler correctly catches and re-raises API-specific errors.
+    """
+    # Mock the API call to raise an exception
+    mock_openai_client.chat.completions.create.side_effect = APIError("API connection failed.", request=MagicMock(spec=httpx.Request), body=None)
+
+    request = LLMRequest(
+        model="gpt-3.5-turbo",
+        messages=[Message(role="user", content="Test API error.", name='Test')],
+    )
+
+    with pytest.raises(RuntimeError, match="An OpenAI API error occurred:.*"):
+        openai_handler.generate(request)


### PR DESCRIPTION
This commit introduces a new handler for the OpenAI API, refactors the client-side schemas, and includes new unit tests for both the OpenAI and Gemini handlers.

* **New OpenAI Handler**: Implemented a dedicated `OpenAIHandler` that adheres to the `BaseHandler` interface, providing a standardized way to interact with the OpenAI API. This handler includes logic for adapting requests, making API calls, and robust error handling.
* **Schema Refactor**: The `ModelConfig` schema was updated to rename the `url` field to `base_url` for better clarity and alignment with the `openai` library's client constructor. The `GeminiHandler` was also refactored to retrieve its API key from the `ModelConfig` object, improving consistency.
* **Unit Testing**: Added a comprehensive test suite for the new `OpenAIHandler`, ensuring it handles successful responses, empty responses, and API errors correctly. The `test_gemini_handler` fixture was also updated to align with the refactored `__init__` method.