### PR TITLE
fix(agents): Correctly split large data payloads

### DIFF
--- a/src/twinrad/threat_hunting/knowledge/agents.py
+++ b/src/twinrad/threat_hunting/knowledge/agents.py
@@ -108,22 +108,54 @@ class GraphBuilderAgent(BaseAgent):
     def __init__(self, config: AgentConfig, client_manager: ClientManager):
         super().__init__(config, client_manager)
         self.config.tool_use = 'TOOL_USE_DIRECT'
+        self.max_prompt_length = 30000
         self.tool = tools.MindMapGraphBuilder(config=ToolConfig())
 
     async def generate(self, messages: List[Message]) -> Message:
         last_message = deepcopy(messages[-1])
         message_content = json.loads(last_message.content)
+        data_payloads = []
         for content in message_content:
             data_payload = content.get('data', '')
             if not data_payload:
                 continue
 
+            data_payloads += self._split_data_payload(data_payload)
+
+        for data_payload in data_payload:
             mind_map_message = await self.generate_llm_message([Message(role='user', content=data_payload, name=self.name)])
             mind_map_json_output = self.postprocess_llm_output(mind_map_message.content)
             await self.tool.run(json_output=mind_map_json_output)
 
         node_labels = ', '.join([label for label, label_type in self.tool.graph.all_nodes if label_type in ['CentralIdea', 'MainTopic']])
         return Message(role='assistant', content=node_labels, name=self.name)
+
+    def _split_data_payload(self, data_payload: str) -> List[str]:
+        """
+        Splits a data payload string into a list of smaller strings,
+        each not exceeding self.max_prompt_length, while preserving line breaks.
+        """
+        lines  = data_payload.split('\n')
+        chunks: List[str] = []
+        current_chunk  = ''
+        current_length  = 0
+
+        for line in lines:
+            line_with_newline = line + '\n'
+            line_length = len(line_with_newline)
+
+            if current_length + line_length > self.max_prompt_length and current_chunk:
+                chunks.append(current_chunk)
+                current_chunk  = line_with_newline
+                current_length  = line_length
+            else:
+                current_chunk += line_with_newline
+                current_length += line_length
+
+        if current_chunk:
+            chunks.append(current_chunk)
+
+        return chunks
 
     def postprocess_llm_output(self, message_content: str) -> str:
         self.logger.debug(f'message_content: {message_content}')


### PR DESCRIPTION
The `GraphBuilderAgent` was unable to process large data payloads due to exceeding the maximum prompt length.

This change introduces a new private method, `_split_data_payload`, which splits large strings into smaller chunks while preserving line breaks. This ensures that the agent can handle payloads of any size by processing them in multiple requests.

The `generate` method is updated to use this new helper function and iterate over the generated chunks.